### PR TITLE
Update rb-scpt to 1.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.0)
-    rb-scpt (1.0.2)
+    rb-scpt (1.0.3)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)


### PR DESCRIPTION
This allows installation on macOS 10.14 Mojave, see #4